### PR TITLE
Fix Stack project

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ packages:
   - '.'
 extra-deps:
   - git: https://github.com/fizruk/telegram-bot-simple.git
-    commit: v0.2
+    commit: f56c45a3aaeaf3842406d3098de2aafa4251e97d


### PR DESCRIPTION
Hello and thank you for this project!

I was going through the preparation, but `stack` was giving me this error:
```
Cannot complete repo information for a non SHA1 commit due to non-reproducibility: Git repo at https://github.com/fizruk/telegram-bot-simple.git, commit v0.2
```
(My Stack version is 2.1.3)

As far as I could understand, Stack wanted a full SHA1 commit id instead of just the tag: https://github.com/commercialhaskell/stack/issues/4882. So, I went and got the last one from here: https://github.com/fizruk/telegram-bot-simple/commits/v0.2.

Looks like Stack is happy now.