### PR TITLE
Update deps causing failed build + outdated telegram-bot-api

### DIFF
--- a/demo-bot.cabal
+++ b/demo-bot.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9c46390282370b2b9642ae5ecba297c140af926abdea4f2ca68059f45806eaeb
+-- hash: 1b17b0b06a1fffa8ed7ae7cc915aa9b6435fd638cd36c6e05dd7fc7d3edc5806
 
 name:           demo-bot
 version:        0.1.0
@@ -16,10 +18,9 @@ maintainer:     nickolay.kudasov@gmail.com
 copyright:      Nickolay Kudasov
 license:        BSD3
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
-    PREPARE.md
     README.md
+    PREPARE.md
 
 source-repository head
   type: git
@@ -41,6 +42,7 @@ executable demo-bot
     , mtl
     , servant-client
     , telegram-bot-simple
+    , telegram-bot-api
     , text
     , time
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,8 @@
-resolver: nightly-2018-06-01
+resolver: nightly-2024-08-25
 packages:
   - '.'
 extra-deps:
   - git: https://github.com/fizruk/telegram-bot-simple.git
-    commit: v0.2
+    commit: 'f7acd0a9feb7fd9beb0ec621a2fe271f6721d51c'
+    subdirs:
+      - telegram-bot-simple


### PR DESCRIPTION
In the process of solving https://github.com/fizruk/telegram-bot-simple/issues/188, I fixed a few things to get it to build again and figured I'd PR.

The original extra-deps in `stack.yaml`:

```yaml
extra-deps:
  - git: https://github.com/fizruk/telegram-bot-simple.git
    commit: v0.2
```

led to:
```zsh

> stack build

Error: [S-112]
       Cannot complete repo information for a non SHA1 commit due to non-reproducibility:
       Git repo at https://github.com/fizruk/telegram-bot-simple.git, commit v0.2.
```

After some googling, saw this https://github.com/commercialhaskell/stack/issues/4882, which hinted that the issue was with not having a full hash for the commit.

I updated to:

```yaml
extra-deps:
  - git: https://github.com/fizruk/telegram-bot-simple.git
    commit: 'f7acd0a9feb7fd9beb0ec621a2fe271f6721d51c'
    subdirs:
      - telegram-bot-simple
 ```

Which worked, but then led to this:

```zsh
In the dependencies for telegram-bot-simple-0.14.1:
         * telegram-bot-api must match >=7.3.1, but telegram-bot-api-6.7.1 is in the Stack configuration
           (latest matching version is 7.4).
       The above is/are needed due to demo-bot-0.1.0 -> telegram-bot-simple-0.14.1
```

Also GHC 8.4.3 didn't even have a build for Mac 14.5.

Added new resolver: 

```zsh 
resolver: nightly-2024-08-25
```

Everything works, also addresses the version bump needed to fix https://github.com/fizruk/telegram-bot-simple/issues/188